### PR TITLE
change source version format

### DIFF
--- a/UserLeapKit.podspec
+++ b/UserLeapKit.podspec
@@ -17,7 +17,7 @@ from your UserLeap Sales contact.
     s.author                = { "The UserLeap Team" => "ios@userleap.com" }
     s.source                = { 
                                 :git => "https://github.com/UserLeap/userleap-ios-sdk-releases.git", 
-                                :tag => "v#{s.version}" 
+                                :tag => s.version.to_s
                               }    
     s.source_files          = "UserLeapKit.framework/Headers/*.h"
     s.public_header_files   = "UserLeapKit.framework/Headers/*.h"


### PR DESCRIPTION
## Description

Unable to set `UserLeapKit` as a podspec dependency because I get a malformed error when doing `pod install`. semver expects numbers and periods so this makes sense

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should also allow people to finally do `pod 'UserLeapKit', '~> 3.1.0'` instead of the current `pod 'UserLeapKit', :git => 'https://github.com/UserLeap/userleap-ios-sdk-releases.git'`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Are Network Changes Included?

Does this change introduce new network connections to any UserLeap resources or third parties?

- [ ] Yes
- [x] No

If yes, have you taken every precaution to limit potential data exposure using best-practice encryption and secure connection protocols?

- [ ] Yes
- [ ] No

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- https://www.notion.so/userleap/Day-To-Day-Development-7682fdcdd7b147368ef430657fa187bd -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. <!--- https://app.gitbook.com/@userleap/s/docs-v1/ -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
