### PR TITLE
Specify to Cocoapods to exclude arm64 for the simulator build for its dummy app

### DIFF
--- a/UserLeapKit.podspec
+++ b/UserLeapKit.podspec
@@ -25,4 +25,8 @@ from your UserLeap Sales contact.
     s.platform              = :ios
     s.swift_version         = "5.3"
     s.ios.deployment_target = '10.3'
+    s.pod_target_xcconfig = {
+      'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
+    }
+    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
## Description
When publishing to Cocoapods, `pod trunk push UserLeapKit.podspec` creates a temporary Xcode project which downloads and builds the project with the specified framework. By default it will try to build for all architectures but since the SDK does not support arm64 on simulator (for apple silicon) the build was failing. We need to explicitly add the `EXCLUDED_ARCHS` to the podspec as mentioned by [this wonderful gentleman](https://github.com/CocoaPods/CocoaPods/issues/10065#issuecomment-694266259).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enables us to deploy to Cocoapods

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
successfully pushed to Cocoapods

## Are Network Changes Included?

Does this change introduce new network connections to any UserLeap resources or third parties?

- [ ] Yes
- [x] No

If yes, have you taken every precaution to limit potential data exposure using best-practice encryption and secure connection protocols?

- [ ] Yes
- [ ] No

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- https://www.notion.so/userleap/Day-To-Day-Development-7682fdcdd7b147368ef430657fa187bd -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. <!--- https://app.gitbook.com/@userleap/s/docs-v1/ -->
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
