### PR TITLE
Added workflow to automatically publish legacy builds

### DIFF
--- a/.github/workflows/legacy-release.yml
+++ b/.github/workflows/legacy-release.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [labeled]
 jobs:
-  label-added:
+  create-legacy-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,6 +37,7 @@ jobs:
       - name: Close pull request
         uses: peter-evans/close-pull@v2
         with:
+          token: ${{ secrets.GH_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           comment: Auto-closing pull request
           delete-branch: true

--- a/.github/workflows/legacy-release.yml
+++ b/.github/workflows/legacy-release.yml
@@ -1,0 +1,42 @@
+name: Legacy Label Release
+on:
+  pull_request:
+    types: [labeled]
+jobs:
+  label-added:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - name: Check label name
+        id: check_label_name
+        run: |
+          if [[ "${{ github.event.label.name }}" =~ ^legacy$ ]]; then
+            echo "Execute legacy labeled release"
+          else
+            echo "Abort legacy labeled release"
+            exit 1
+          fi
+
+      - name: Get Version
+        id: get-version
+        run: echo "version=$(grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" UserLeapKit.podspec)-legacy" >> $GITHUB_OUTPUT
+
+      - name: Create Tag
+        run: bash ./scripts/tag-and-release.sh tag ${{ secrets.GH_TOKEN }} ${{ steps.get-version.outputs.version }}
+
+      - name: Create release
+        run: bash ./scripts/tag-and-release.sh release ${{ secrets.GH_TOKEN }} ${{ steps.get-version.outputs.version }}
+      
+      - name: Push to Cocoapod
+        env: 
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.POD_TRUNK_TOKEN }}
+        run: pod trunk push UserLeapKit.podspec
+
+      - name: Close pull request
+        uses: peter-evans/close-pull@v2
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          comment: Auto-closing pull request
+          delete-branch: true

--- a/.github/workflows/legacy-release.yml
+++ b/.github/workflows/legacy-release.yml
@@ -4,7 +4,7 @@ on:
     types: [labeled]
 jobs:
   create-legacy-release:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/scripts/tag-and-release.sh
+++ b/scripts/tag-and-release.sh
@@ -5,9 +5,15 @@ set -e
 readonly ACTION="$1"
 readonly GH_TOKEN="$2"
 readonly TAG_NAME="$3"
+
+MAKE_LATEST=true
 if [[ -z "$GH_TOKEN" ]] || [[ -z "$ACTION" ]] || [[ -z "$TAG_NAME" ]]; then
     echo "The action, access token, or tag name was not set"
     exit 1
+fi
+
+if [[ "$TAG_NAME" == *"-legacy"* ]]; then
+    MAKE_LATEST=false
 fi
 
 tag() {
@@ -24,6 +30,7 @@ generate_release_payload() {
     "draft":false,
     "prerelease":false,
     "generate_release_notes":true
+    "make_latest":"$MAKE_LATEST"
 }
 EOF
 }


### PR DESCRIPTION
# Added workflow to publish to cocoapods, create tag, and release automatically
<!--- Provide a general summary of your changes in the Title above -->

## Description
The new workflow makes a legacy release
- when the label `legacy` is added
- create a legacy version tag and release
- publish to cocoapods
- close pr and delete branch
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in a private fork
<img width="232" alt="image" src="https://user-images.githubusercontent.com/73458232/218879949-7c806fd9-a498-441e-bdb3-ed012afc4694.png">

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/73458232/218879879-812e0bbf-6cab-4dae-9d4d-73e26cb16abc.png">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Are Network Changes Included?

Does this change introduce new network connections to any UserLeap resources or third parties?

- [ ] Yes
- [ ] No

If yes, have you taken every precaution to limit potential data exposure using best-practice encryption and secure connection protocols?

- [ ] Yes
- [ ] No

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.