### PR TITLE
SDK release 4.13.0

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,17 @@
 # Change Log
+## add: A new feature
+## fix: A bug fix
+## chore: Changes to the build process or auxiliary tools and libraries
 
+### pre-release
+
+### 4.13.0
+add: Add new optional parameter to configure function
+chore: remove storage.swift
+chore: add ios legacy build automation
+chore: update to web sdk 2.21.3
+### 4.12.2
+chore: update to web sdk 2.21.2
 ### 4.12.1
 * New EventPayload object to simplify calling track methods available for ObjC projects
 * Allows public methods (excluding displaySurvey and other UI methods) to be called from a background thread

--- a/UserLeapKit.json
+++ b/UserLeapKit.json
@@ -41,5 +41,6 @@
   "4.11.0": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.11.0.zip",
   "4.11.1": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.11.1.zip",
   "4.12.0": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.12.0.zip",
-  "4.12.1": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.12.1.zip"
+  "4.12.1": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.12.1.zip",
+  "4.13.0": "https://github.com/UserLeap/userleap-ios-sdk-releases/archive/4.13.0.zip"
 }

--- a/UserLeapKit.podspec
+++ b/UserLeapKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = "UserLeapKit"
-    s.version               = "4.12.1"
+    s.version               = "4.13.0"
     s.summary               = "UserLeap surveys in iOS"
     s.description           = <<-DESC
       Access the power of Sprig inside of your iOS applications. Track visitor progress and deliver surveys natively across


### PR DESCRIPTION
iOS SDK release 4.13.0. Changes available in [CHANGE_LOG.md](https://github.com/UserLeap/userleap-ios-sdk-releases/blob/c53681a429355844e504d52100f05b0c9b70c61f/CHANGE_LOG.md)