### PR TITLE
[SDK2416] Remove Cocoapods push from legacy-release.yml

### DIFF
--- a/.github/workflows/legacy-release.yml
+++ b/.github/workflows/legacy-release.yml
@@ -28,11 +28,6 @@ jobs:
 
       - name: Create release
         run: bash ./scripts/tag-and-release.sh release ${{ secrets.GH_TOKEN }} ${{ steps.get-version.outputs.version }}
-      
-      - name: Push to Cocoapod
-        env: 
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.POD_TRUNK_TOKEN }}
-        run: pod trunk push UserLeapKit.podspec
 
       - name: Close pull request
         uses: peter-evans/close-pull@v2


### PR DESCRIPTION
# Title Remove Cocoapods push from legacy-release.yml

 - Remove Cocoapods push from legacy-release.yml

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Are Network Changes Included?

Does this change introduce new network connections to any UserLeap resources or third parties?

- [ ] Yes
- [ ] No

If yes, have you taken every precaution to limit potential data exposure using best-practice encryption and secure connection protocols?

- [ ] Yes
- [ ] No

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
